### PR TITLE
Improve grouping of commands in help display

### DIFF
--- a/bin/chkenv
+++ b/bin/chkenv
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Checks if the specified environment variables are set
+#? [Environment] Checks if the specified environment variables are set
 
 if [ $# -eq 0 ]; then
     echo>&2 "Usage: $0 VAR1 [VAR2 ...]"

--- a/bin/data/download
+++ b/bin/data/download
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Download data from Azure Blob Storage
+#? [Data] Download data from Azure Blob Storage
 
 set -eo pipefail
 cd "$(dirname "$0")/../.."

--- a/bin/data/find
+++ b/bin/data/find
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Find account, container and subdir for a named data asset
+#? [Data] Find account, container and subdir for a named data asset
 
 set -eo pipefail
 cd "$(dirname "$0")/../.."

--- a/bin/data/list
+++ b/bin/data/list
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? List data in a Blob Storage Container
+#? [Data] List data in a Blob Storage Container
 
 set -eo pipefail
 cd "$(dirname "$0")/../.."

--- a/bin/data/register
+++ b/bin/data/register
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Register a data asset in AzureML
+#? [Data] Register a data asset in AzureML
 
 set -eo pipefail
 cd "$(dirname "$0")/../.."

--- a/bin/dev/sync
+++ b/bin/dev/sync
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Ensure dev env is in sync with the repo
+#? [Development] Ensure dev env is in sync with the repo
 
 set -eo pipefail
 cd "$(dirname "$0")/../.."

--- a/bin/dev/test
+++ b/bin/dev/test
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Run pytest for the project with coverage
+#? [Development] Run pytest for the project with coverage
 
 set -eo pipefail
 cd "$(dirname "$0")/../.."

--- a/bin/env
+++ b/bin/env
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Exports variables from an environment file
+#? [Environment] Exports variables from an environment file
 
 default_env="container.env"
 if [[ "$1" == '-h' || "$1" == '--help' ]]; then

--- a/bin/help
+++ b/bin/help
@@ -19,6 +19,10 @@ from typing import Final
 #   HELP        ::= "#" (" ") "?" ( "[" GROUP "]" ) DESCRIPTION
 #   GROUP       ::= any character except "]"
 #   DESCRIPTION ::= any character
+#
+# Example:
+#
+#     #? [Utility] This is a super duper useful command
 
 default_help_line_pattern: Final = re.compile(r"^# ?\? *(?:\[([^\]]+)\] *)?(.+)")
 

--- a/bin/help
+++ b/bin/help
@@ -22,6 +22,8 @@ from typing import Final
 
 default_help_line_pattern: Final = re.compile(r"^# ?\? *(?:\[([^\]]+)\] *)?(.+)")
 
+DEFAULT_GROUP = "Misc"
+
 
 def scan_commands(
     files: Iterable[Path],
@@ -29,7 +31,7 @@ def scan_commands(
     help_line_pattern: re.Pattern[str] | None = None,
     group_index: str | int = 1,
     help_index: str | int = 2,
-    default_group: str = "Misc",
+    default_group: str = DEFAULT_GROUP,
 ) -> Iterator[tuple[Path, str, str]]:
     """
     Scan the files, yielding the file, group, and help text.

--- a/bin/help
+++ b/bin/help
@@ -16,11 +16,11 @@ from typing import Final
 # The help pattern (in pseudo-BNF below) is used to extract the description of a
 # command:
 #
-#   HELP        ::= "#?" ( "[" GROUP "]" ) DESCRIPTION
+#   HELP        ::= "#" (" ") "?" ( "[" GROUP "]" ) DESCRIPTION
 #   GROUP       ::= any character except "]"
 #   DESCRIPTION ::= any character
 
-default_help_line_pattern: Final = re.compile(r"^#\? *(?:\[([^\]]+)\] *)?(.+)")
+default_help_line_pattern: Final = re.compile(r"^# ?\? *(?:\[([^\]]+)\] *)?(.+)")
 
 
 def scan_commands(
@@ -63,7 +63,7 @@ def main() -> None:
     The description of a command is the first line of the file that starts with
     the `help_pattern`. A typical help line looks like this:
 
-        "#?" ( "[" GROUP "]" ) DESCRIPTION
+        "# ?" ( "[" GROUP "]" ) DESCRIPTION
 
     The GROUP is optional and is used to group commands together. If no GROUP is
     provided, the command is grouped under a default group.

--- a/bin/help
+++ b/bin/help
@@ -99,11 +99,11 @@ def main() -> None:
 
     for i, (_, commands) in enumerate(commands_by_group.items()):
         if i > 0:
-            cprint("")
+            cprint()
 
         if len(commands_by_group) > 1:
             cprint(f"# {commands[0].group}", color=Color.BLUE)
-            cprint("")
+            cprint()
 
         for command in commands:
             cprint(f"{command.path_str.ljust(max_file_name_length + 2)} {command.help}")
@@ -114,7 +114,7 @@ class Color(Enum):
     DEFAULT = "\033[0m"
 
 
-def cprint(message: str, color: Color = Color.DEFAULT) -> None:
+def cprint(message: str = "", color: Color = Color.DEFAULT) -> None:
     print(color.value + message if os.isatty(1) else message)
 
 

--- a/bin/help
+++ b/bin/help
@@ -1,14 +1,112 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #? Show this help
 
 import os
-from builtins import print as print_
+import re
 from collections import OrderedDict
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
 from enum import Enum
+from itertools import groupby
+from operator import itemgetter
+from os import fspath
 from pathlib import Path
 from typing import Final
 
-DESCRIPTION_PREFIX: Final = "#?"
+# The help pattern (in pseudo-BNF below) is used to extract the description of a
+# command:
+#
+#   HELP        ::= "#?" ( "[" GROUP "]" ) DESCRIPTION
+#   GROUP       ::= any character except "]"
+#   DESCRIPTION ::= any character
+
+default_help_line_pattern: Final = re.compile(r"^#\? *(?:\[([^\]]+)\] *)?(.+)")
+
+
+def scan_commands(
+    files: Iterable[Path],
+    *,
+    help_line_pattern: re.Pattern[str] | None = None,
+    group_index: str | int = 1,
+    help_index: str | int = 2,
+    default_group: str = "Misc",
+) -> Iterator[tuple[Path, str, str]]:
+    """
+    Scan the files, yielding the file, group, and help text.
+    """
+    help_line_pattern = help_line_pattern or default_help_line_pattern
+    for file in files:
+        with file.open() as lines:
+            match = next((m for line in lines if (m := help_line_pattern.match(line))), None)
+        group, help_ = (
+            ((match.group(group_index) or default_group).strip(), match.group(help_index).strip())
+            if match
+            else (default_group, "")
+        )
+        yield (file, group, help_)
+
+
+@dataclass(frozen=True)
+class Command:
+    path: Path
+    path_str: str
+    group: str
+    group_key: str
+    help: str
+
+
+def main() -> None:
+    """
+    Print the description of all the commands (executable scripts) in the same
+    directory as this script, including sub-directories. Commands are grouped.
+
+    The description of a command is the first line of the file that starts with
+    the `help_pattern`. A typical help line looks like this:
+
+        "#?" ( "[" GROUP "]" ) DESCRIPTION
+
+    The GROUP is optional and is used to group commands together. If no GROUP is
+    provided, the command is grouped under a default group.
+    """
+    scan_root_path = Path(__file__).parent
+
+    commands = [
+        Command(
+            path=file,
+            path_str=fspath(file.relative_to(scan_root_path.parent)),
+            group=group,
+            group_key=group.lower(),  # normalized for grouping/sorting
+            help=help_,
+        )
+        for file, group, help_ in scan_commands(
+            path
+            for path in scan_root_path.rglob("*")
+            if path.is_file() and os.access(path, os.X_OK)
+        )
+        if fspath(file) != __file__  # exclude this file
+    ]
+
+    max_file_name_length = max(len(c.path_str) for c in commands)
+
+    commands_by_group = OrderedDict(
+        (group, list(m[-1] for m in members))
+        for group, members in groupby(
+            # sort by group, then by path
+            sorted(((c.group_key, c.path_str, c) for c in commands), key=itemgetter(0, 1)),
+            key=itemgetter(0),
+        )
+    )
+
+    for i, (_, commands) in enumerate(commands_by_group.items()):
+        if i > 0:
+            cprint("")
+
+        if len(commands_by_group) > 1:
+            cprint(f"# {commands[0].group}", color=Color.BLUE)
+            cprint("")
+
+        for command in commands:
+            cprint(f"{command.path_str.ljust(max_file_name_length + 2)} {command.help}")
 
 
 class Color(Enum):
@@ -16,64 +114,8 @@ class Color(Enum):
     DEFAULT = "\033[0m"
 
 
-def main() -> None:
-    """
-    Print the description of all the commands in the bin directory.
-
-    Commands are grouped by the directory they are in.
-
-    The description of a command is the first line of the file that starts with
-    the DESCRIPTION_PREFIX. The DESCRIPTION_PREFIX is removed from the
-    description.
-    """
-    current_dir = Path(__file__).parent
-
-    commands: dict[Path, dict[str, str]] = OrderedDict()
-
-    for dir, file_name in [
-        (Path(dir), file) for dir, _, filenames in os.walk(current_dir) for file in filenames
-    ]:
-        file = dir / file_name
-
-        if not os.access(file, os.X_OK):
-            # Skip if the file is not executable
-            continue
-
-        with open(file) as file:
-            lines = file.readlines()
-
-        lines = [
-            line.replace(DESCRIPTION_PREFIX, "").strip()
-            for line in lines
-            if line.startswith(DESCRIPTION_PREFIX)
-        ]
-
-        if dir not in commands:
-            commands[dir] = {}
-
-        commands[dir][file_name] = lines[0] if lines else ""
-
-    def print(message: str, color: Color = Color.DEFAULT) -> None:
-        print_(color.value + message)
-
-    def relative_path(path: Path) -> str:
-        return str(path.relative_to(os.getcwd()))
-
-    max_file_name_length = max(
-        len(relative_path(dir / name))
-        for dir, command in commands.items()
-        for name, _ in command.items()
-    )
-
-    print("")
-    for dir, files in commands.items():
-        print(f"# {'GENERAL' if dir.name == 'bin' else dir.name.upper()}", color=Color.BLUE)
-
-        for file, help in files.items():
-            file_path = str(relative_path(dir / file))
-            print(f"{file_path.ljust(max_file_name_length + 2)} {help}")
-
-        print("")
+def cprint(message: str, color: Color = Color.DEFAULT) -> None:
+    print(color.value + message if os.isatty(1) else message)
 
 
 if __name__ == "__main__":

--- a/bin/help
+++ b/bin/help
@@ -24,7 +24,7 @@ from typing import Final
 #
 #     #? [Utility] This is a super duper useful command
 
-default_help_line_pattern: Final = re.compile(r"^# ?\? *(?:\[([^\]]+)\] *)?(.+)")
+default_help_line_pattern: Final = re.compile(r"^# ?\? *(?:\[(?P<group>[^\]]+)\] *)?(?P<help>.+)")
 
 DEFAULT_GROUP = "Misc"
 

--- a/bin/help
+++ b/bin/help
@@ -112,16 +112,23 @@ def main() -> None:
             cprint()
 
         for command in commands:
-            cprint(f"{command.path_str.ljust(max_file_name_length + 2)} {command.help}")
+            cprint(command.path_str, color=Color.CYAN, end="")
+            cprint(f"{' ' * (max_file_name_length + 2 - len(command.path_str))} {command.help}")
 
 
 class Color(Enum):
+    CYAN = "\033[96m"
     BLUE = "\033[94m"
     DEFAULT = "\033[0m"
 
 
-def cprint(message: str = "", color: Color = Color.DEFAULT) -> None:
-    print(color.value + message if os.isatty(1) else message)
+def cprint(
+    message: str = "",
+    color: Color = Color.DEFAULT,
+    *,
+    end: str | None = "\n",
+) -> None:
+    print(color.value + message if os.isatty(1) else message, end=end)
 
 
 if __name__ == "__main__":

--- a/bin/lint/md
+++ b/bin/lint/md
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Lints Markdown files and validate their links
+#? [Linting] Lints Markdown files and validate their links
 
 set -eo pipefail
 cd "$(dirname "$0")/../.."

--- a/bin/lint/py
+++ b/bin/lint/py
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#?  Format, line and type check all Python files in ${CODE_PATH}
+#? [Linting] Format, line and type check all Python files in ${CODE_PATH}
 
 set -eo pipefail
 cd "$(dirname "$0")/../.."

--- a/bin/lint/shell
+++ b/bin/lint/shell
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Checks shell scripts for potential issues
+#? [Linting] Checks shell scripts for potential issues
 set -eo pipefail
 cd "$(dirname "$0")/../.."
 

--- a/bin/pipe/aml
+++ b/bin/pipe/aml
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Run an experiment as a job in AzureML
+#? [Pipeline] Run an experiment as a job in AzureML
 
 set -eo pipefail
 cd "$(dirname "$0")/../.."

--- a/bin/pipe/iso
+++ b/bin/pipe/iso
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Isolate artifacts for an package run in a separate directory
+#? [Pipeline] Isolate artifacts for an package run in a separate directory
 
 set -eo pipefail
 cd "$(dirname "$0")/../.."

--- a/bin/pipe/local
+++ b/bin/pipe/local
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Execute package locally as it would in AzureML
+#? [Pipeline] Execute package locally as it would in AzureML
 
 set -eo pipefail
 cd "$(dirname "$0")/../.."

--- a/bin/pipe/new
+++ b/bin/pipe/new
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Initialize new pipeline in the project
+#? [Pipeline] Initialize new pipeline in the project
 
 set -eo pipefail
 cd "$(dirname "$0")/../.."

--- a/bin/pkg/aml
+++ b/bin/pkg/aml
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Run an experiment as a job in AzureML
+#? [Package] Run an experiment as a job in AzureML
 
 set -eo pipefail
 cd "$(dirname "$0")/../.."

--- a/bin/pkg/iso
+++ b/bin/pkg/iso
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Isolate artifacts for an package run in a separate directory
+#? [Package] Isolate artifacts for an package run in a separate directory
 
 set -eo pipefail
 cd "$(dirname "$0")/../.."

--- a/bin/pkg/local
+++ b/bin/pkg/local
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Execute package locally as it would in AzureML
+#? [Package] Execute package locally as it would in AzureML
 
 set -eo pipefail
 cd "$(dirname "$0")/../.."

--- a/bin/pkg/name
+++ b/bin/pkg/name
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Generate a random name for an experiment run
+#? [Package] Generate a random name for an experiment run
 
 # Adjectives and nouns copied from Moby project:
 #    https://github.com/moby/moby/blob/master/pkg/namesgenerator/names-generator.go

--- a/bin/pkg/new
+++ b/bin/pkg/new
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Initialize new package in the project
+#? [Package] Initialize new package in the project
 
 set -eo pipefail
 cd "$(dirname "$0")/../.."

--- a/bin/pkg/rm
+++ b/bin/pkg/rm
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#? Remove an package from the workspace
+#? [Package] Remove an package from the workspace
 
 set -eo pipefail
 cd "$(dirname "$0")/../.."


### PR DESCRIPTION
This PR improves the help display such that instead of being dependent on the directory structure and name to create groupings and titles, it lets the help description of each script indicate the group it belongs to via the `[GROUP]` syntax.

Running:

```sh
bin/help
```

now displays:

    # Data
    
    bin/data/download   Download data from Azure Blob Storage
    bin/data/find       Find account, container and subdir for a named data asset
    bin/data/list       List data in a Blob Storage Container
    bin/data/register   Register a data asset in AzureML
    
    # Development
    
    bin/dev/sync        Ensure dev env is in sync with the repo
    bin/dev/test        Run pytest for the project with coverage
    
    # Environment
    
    bin/chkenv          Checks if the specified environment variables are set
    bin/env             Exports variables from an environment file
    
    # Linting
    
    bin/lint/md         Lints Markdown files and validate their links
    bin/lint/py         Format, line and type check all Python files in ${CODE_PATH}
    bin/lint/shell      Checks shell scripts for potential issues
    
    # Package
    
    bin/pkg/aml         Run an experiment as a job in AzureML
    bin/pkg/iso         Isolate artifacts for an package run in a separate directory
    bin/pkg/local       Execute package locally as it would in AzureML
    bin/pkg/name        Generate a random name for an experiment run
    bin/pkg/new         Initialize new package in the project
    bin/pkg/rm          Remove an package from the workspace
    
    # Pipeline
    
    bin/pipe/aml        Run an experiment as a job in AzureML
    bin/pipe/iso        Isolate artifacts for an package run in a separate directory
    bin/pipe/local      Execute package locally as it would in AzureML
    bin/pipe/new        Initialize new pipeline in the project
