### PR TITLE
Fix potential infinite loop in shell lint script

### DIFF
--- a/bin/lint/shell
+++ b/bin/lint/shell
@@ -31,6 +31,11 @@ EOF
 
 function check_all {
     mapfile -t < <("$0" ls-tracked) # Read into an array
+    # If the array is empty, print a message and exit
+    if [ ${#MAPFILE[@]} -eq 0 ]; then
+        echo >&2 'No executable and tracked shell scripts found.'
+        exit
+    fi
     "$0" check "${MAPFILE[@]}"
 }
 


### PR DESCRIPTION
This PR fixes a bug where the `bin/lint/shell` could enter an infinite loop if its `ls-tracked` sub-command returned nothing. This can happen, for example, if `git ls-files` itself fails as part of `ls-tracked`.
