### PR TITLE
Check `git` requirements before shell linting

### DIFF
--- a/bin/lint/shell
+++ b/bin/lint/shell
@@ -34,12 +34,25 @@ function check_all {
     "$0" check "${MAPFILE[@]}"
 }
 
+function check_git {
+    if ! git ls-files '?' --format=test 1>/dev/null 2>&1; then
+        if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+            echo >&2 'Not in a Git repository.'
+        else
+            echo >&2 'You need a version of Git whose "ls-files" sub-command supports the "--format" option.'
+        fi
+        exit 1
+    fi
+}
+
 case "$1" in
     "")
+        check_git
         check_all
         exit
         ;;
     ls-tracked)
+        check_git
         git ls-files --format="%(objectmode):%(path)" |
             grep -E '^100755:' | # Only executable files
             while IFS=: read -r mode path; do


### PR DESCRIPTION
This PR fixes `bin/lint/shell` to check that:

1. the command is run in a Git working tree, and
2. Git's `ls-files` supports the `--format` option.

The Git version on my machine was old enough that `ls-files` didn't recognise the `--format` option. This caused the script to enter into an infinite loop because it didn't err. The infinite loop is fixed by #20 (which can happen even if `ls-files` doesn't fail but returns an empty list), but this PR causes the script to fail with helpful error messages depending on the problem.
