### PR TITLE
Make help text required and refactor `bin/help`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     args: [check]
     language: script
     files: ^.*\.sh|^bin/
-    exclude: ^.*\.yaml|^.env.*|.*\.md
+    exclude: ^.*\.yaml|^.env.*|.*\.md|bin/help
   - id: python
     name: Lint Python
     entry: bin/lint/py

--- a/bin/help
+++ b/bin/help
@@ -1,15 +1,11 @@
-#!/usr/bin/env python3
-# ? Show this help
+#!/usr/bin/env -S uv run --script
 
 import os
 import re
-from collections import OrderedDict
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import Enum
-from itertools import groupby
-from operator import itemgetter
-from os import fspath
+from itertools import chain, groupby
 from pathlib import Path
 from typing import Final
 
@@ -24,41 +20,11 @@ from typing import Final
 #
 #     #? [Utility] This is a super duper useful command
 
-default_help_line_pattern: Final = re.compile(r"^# ?\? *(?:\[(?P<group>[^\]]+)\] *)?(?P<help>.+)")
-
-DEFAULT_GROUP = "Misc"
-
-
-def scan_commands(
-    files: Iterable[Path],
-    *,
-    help_line_pattern: re.Pattern[str] | None = None,
-    group_index: str | int = 1,
-    help_index: str | int = 2,
-    default_group: str = DEFAULT_GROUP,
-) -> Iterator[tuple[Path, str, str]]:
-    """
-    Scan the files, yielding the file, group, and help text.
-    """
-    help_line_pattern = help_line_pattern or default_help_line_pattern
-    for file in files:
-        with file.open() as lines:
-            match = next((m for line in lines if (m := help_line_pattern.match(line))), None)
-        group, help_ = (
-            ((match.group(group_index) or default_group).strip(), match.group(help_index).strip())
-            if match
-            else (default_group, "")
-        )
-        yield (file, group, help_)
-
-
-def should_display_help(filepath: Path) -> bool:
-    return (
-        filepath.is_file()
-        and os.access(filepath, os.X_OK)
-        and not filepath.suffix
-        and not filepath.name.startswith("_")
-    )
+HELP_LINE_PATTERN: Final = re.compile(r"^# ?\? *(?:\[(?P<group>[^\]]*)\] *)?(?P<help>.*)")
+GROUP_NAME: Final = "group"
+HELP_NAME: Final = "help"
+DEFAULT_GROUP: Final = "misc"
+DEFAULT_DESCRIPTION: Final = f"#? [{DEFAULT_GROUP}]"
 
 
 @dataclass(frozen=True)
@@ -66,8 +32,48 @@ class Command:
     path: Path
     path_str: str
     group: str
-    group_key: str
     help: str
+
+
+def enumerate_commands(root: Path, /) -> Iterator[Command]:
+    """
+    Scan for all commands from the root directory recursively.
+    """
+
+    def should_display_help(file: Path) -> bool:
+        return (
+            file.is_file()
+            and os.access(file, os.X_OK)
+            and not file.suffix
+            and not file.name.startswith("_")
+            and not file == Path(__file__)  # Exclude this script itself
+        )
+
+    for file in root.rglob("*"):
+        if not should_display_help(file):
+            continue
+
+        with file.open() as lines:
+            match = next(
+                m
+                for line in chain(lines, [DEFAULT_DESCRIPTION])
+                if (m := HELP_LINE_PATTERN.match(line))
+            )
+
+        help = match.group(HELP_NAME)
+
+        if not help:
+            raise ValueError(
+                f"Command '{file}' does not have a valid help line. "
+                "Expected format: '#? [GROUP] DESCRIPTION'."
+            )
+
+        yield Command(
+            path=(p := file.relative_to(root.parent)),
+            path_str=str(p),
+            group=(match.group(GROUP_NAME) or DEFAULT_GROUP).lower(),
+            help=help,
+        )
 
 
 def main() -> None:
@@ -83,46 +89,21 @@ def main() -> None:
     The GROUP is optional and is used to group commands together. If no GROUP is
     provided, the command is grouped under a default group.
     """
-    scan_root_path = Path(__file__).parent
 
-    commands = [
-        Command(
-            path=file,
-            path_str=fspath(file.relative_to(scan_root_path.parent)),
-            group=group,
-            group_key=group.lower(),  # normalized for grouping/sorting
-            help=help_,
-        )
-        for file, group, help_ in scan_commands(
-            path
-            for path in scan_root_path.rglob("*")
-            if should_display_help(path)
-        )
-        if fspath(file) != __file__  # exclude this file
-    ]
-
-    max_file_name_length = max(len(c.path_str) for c in commands)
-
-    commands_by_group = OrderedDict(
-        (group, list(m[-1] for m in members))
-        for group, members in groupby(
-            # sort by group, then by path
-            sorted(((c.group_key, c.path_str, c) for c in commands), key=itemgetter(0, 1)),
-            key=itemgetter(0),
-        )
+    all_commands = list(
+        sorted(enumerate_commands(Path(__file__).parent), key=lambda c: (c.group, c.path_str))
     )
 
-    for i, (_, commands) in enumerate(commands_by_group.items()):
-        if i > 0:
-            cprint()
+    column_width = max(len(c.path_str) for c in all_commands) + 2
 
-        if len(commands_by_group) > 1:
-            cprint(f"# {commands[0].group}", color=Color.BLUE)
-            cprint()
+    for group, commands in groupby(all_commands, key=lambda c: c.group):
+        cprint(f"# {group.capitalize()}", color=Color.BLUE)
 
         for command in commands:
-            cprint(command.path_str, color=Color.CYAN, end="")
-            cprint(f"{' ' * (max_file_name_length + 2 - len(command.path_str))} {command.help}")
+            cprint(command.path_str.ljust(column_width), color=Color.CYAN, end="")
+            cprint(command.help)
+
+        cprint()
 
 
 class Color(Enum):

--- a/bin/help
+++ b/bin/help
@@ -35,9 +35,9 @@ class Command:
     help: str
 
 
-def enumerate_commands(root: Path, /) -> Iterator[Command]:
+def scan_commands(root: Path, /) -> Iterator[Command]:
     """
-    Scan for all commands from the root directory recursively.
+    Scan the files, yielding the file, group, and help text.
     """
 
     def should_display_help(file: Path) -> bool:
@@ -91,7 +91,7 @@ def main() -> None:
     """
 
     all_commands = list(
-        sorted(enumerate_commands(Path(__file__).parent), key=lambda c: (c.group, c.path_str))
+        sorted(scan_commands(Path(__file__).parent), key=lambda c: (c.group, c.path_str))
     )
 
     column_width = max(len(c.path_str) for c in all_commands) + 2


### PR DESCRIPTION
This PR fixes some issues with the help text parsing, specifically for the following help lines (using the example of `bin/env`:

```txt
#? [Environment]
#?
#? [] description
```

before the change, this would result in the following help text:

```txt
bin/env             [Environment]
bin/env             
bin/env             [] description
```

after the change, the first two examples become invalid and raises an exception (optional descriptions are disallowed according to the documentation). Having no help line is now also disallowed. The third example is interpreted as an empty/default group and now becomes:

```txt
bin/env            description
```

An alternative solution would have been to update the documentation and declare that the help text is optional.

The PR includes some unrelated changes, such as some general refactoring for readability and succinctness. Most notably, we:

- use a shebang to run the `bin/help` script with `uv` for more portability
- use fewer imports and less code for the implementation

As a (breaking) side-effect, the output format of `bin/help` is slightly and reduces the empty newlines after group titles. Happy to revert the unrelated changes and fix only the underlying issue at hand.